### PR TITLE
wavtospice.py: Add cast to float to avoid downcast to integer.

### DIFF
--- a/wavtospice.py
+++ b/wavtospice.py
@@ -22,7 +22,7 @@ def read_wav(filename):
             temp = struct.unpack_from("<i", '\x00'+waveData)
         else:
             raise ValueError('Unsupported sample width')
-        data.append((t*timestep,temp[0]/(2**(8*sampwidth-1)-1)))
+        data.append((t*timestep,float(temp[0])/(2**(8*sampwidth-1)-1)))
         t += 1
     vrms = sqrt(1.0/(len(data[1]))*sum(i**2 for i in data[1]))
     print 'RMS voltage:',vrms


### PR DESCRIPTION
Running this on my system resulted in an output file with integer values in the second column. Adding a cast to float seems to have fixed the issue for me. My version of Python is:

Python 2.7.6 (default, Feb 26 2014, 12:07:17) 
[GCC 4.8.2 20140206 (prerelease)] on linux2

Thanks for the useful tool, by the way. I'm just getting in to circuit simulation with ngspice and this was a time saver. Cheers!
